### PR TITLE
Task to change ownership of persisted data folder

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -46,3 +46,10 @@
       when: apply_patches | bool
       notify: restart pulsar
       ignore_errors: yes
+    - name: Change file ownership and group for persisted_data folder
+      file: 
+        path: "{{ pulsar_data_path }}/persisted_data"
+        state: directory
+        recurse: yes
+        owner: pulsar
+        group: pulsar


### PR DESCRIPTION
Added a task to ensure pulsar is the owner and group for the persisted_data folder within the "{{ pulsar_data_path }}"